### PR TITLE
Upgrade dependencies and tiles and build process:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2010 RedEngine Ltd, http://www.redengine.co.nz. All rights reserved. -->
+<!-- Copyright (c) 2023 RedEngine Ltd, http://www.redengine.co.nz. All rights reserved. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
-    <groupId>net.stickycode.parent</groupId>
-    <artifactId>sticky-parent-jar8</artifactId>
-    <version>3.1</version>
+    <groupId>net.stickycode.stable.parent</groupId>
+    <artifactId>sticky-parent</artifactId>
+    <version>1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -25,26 +25,28 @@
   </scm>
 
   <prerequisites>
-    <maven>3.5.0</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>[3.5.1]</version>
+      <version>[3.6.0]</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>[3.5.2]</version>
+      <version>[3.6.3]</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>[3.5.2]</version>
+      <version>[3.6.3]</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 
@@ -65,10 +67,21 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
     <plugins>
       <plugin>
+        <groupId>io.repaint.maven</groupId>
+        <artifactId>tiles-maven-plugin</artifactId>
+        <version>2.34</version>
+        <configuration>
+          <tiles>
+            <tile>net.stickycode.tile:sticky-tile-release:[2,3)</tile>
+          </tiles>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.9.0</version>
         <configuration>
           <goalPrefix>wait</goalPrefix>
         </configuration>


### PR DESCRIPTION
maven 3.9.2 is harsh for anything out in the plugin definition so use provided scope
move to tiles from functional parents
require the usage of at leave maven 3.6.3 its the oldest currently supported maven version
